### PR TITLE
Add save/load for drawing styles (fixes #262)

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -4176,6 +4176,7 @@ function doOnLoad() {
     // load settings from storage
     loadSettingsStorage();
     loadPrintDialogStorage();
+    loadDrawingStyles();
 
     // load private logos
     {
@@ -5743,7 +5744,20 @@ function savePrintDialogStorage() {
     });
     localStorage.setItem('printDialog', JSON.stringify(settings));
 }
+// saveDrawingStyles will save drawing styles to localStorage
+function saveDrawingStyles() {
+  localStorage.setItem('drawingStyles', JSON.stringify(OA.style));
+}
 
+// loadDrawingStyles will load drawing styles from localStorage
+function loadDrawingStyles() {
+  const styles = JSON.parse(localStorage.getItem('drawingStyles') || 'null');
+  if (styles) {
+for (const key in styles) {
+     if (key in OA.style) OA.style[key] = styles[key];
+    }
+  }
+}
 // loadPrintDialogStorage will load the the print dialog settings from
 // storage
 function loadPrintDialogStorage() {
@@ -5815,6 +5829,7 @@ function updateStyle() {
     }
     // redraw sequence
     draw();
+    saveDrawingStyles();
 }
 
 // resetStyle resets a style (or all) to the default value


### PR DESCRIPTION
Fixes #262

## Problem
Drawing style settings (pos, neg, posfill, negfill, etc. in Settings →
Expert → Drawing styles) reset to their defaults every time the page
is refreshed. Other settings persist via localStorage, but drawing
styles did not.

## Fix
Added auto-persistence for drawing styles, following the same
localStorage pattern already used for print dialog settings:

- `saveDrawingStyles()` — saves the full `OA.style` object to
  localStorage whenever a style is changed (hooked into `updateStyle()`)
- `loadDrawingStyles()` — reads saved styles from localStorage and
  applies them to `OA.style` on page load (hooked into `doOnLoad()`)

This removes the need for the manual Save/Load file workaround for
routine use — styles now persist automatically across sessions, the
same way other settings already do.

## Testing
- Changed a drawing style (e.g. `pos`) in Settings → Expert
- Refreshed the page
- Confirmed the changed value persisted